### PR TITLE
Handling events API similar to jQuery

### DIFF
--- a/lib/opal/phaser/game_objects/events.rb
+++ b/lib/opal/phaser/game_objects/events.rb
@@ -5,5 +5,18 @@ module Phaser
     include Native
 
     alias_native :on_input_down, :onInputDown, as: Signal
+
+    def on(type, context, &block)
+      case type.to_sym
+      when :up
+        `#@native.onInputUp.add(#{block.to_n}, #{context})`
+      when :down
+        `#@native.onInputDown.add(#{block.to_n}, #{context})`
+      when :out
+        `#@native.onInputOut.add(#{block.to_n}, #{context})`
+      when :over
+        `#@native.onInputOver.add(#{block.to_n}, #{context})`
+      end
+    end
   end
 end


### PR DESCRIPTION
So, in the way of making this looks more like Ruby and less JS I want to propose this Event Handling API.

On Phaser.js when we want to track a event directly we do something like this:
```javascript
var callback = function() {
  console.log("event down")
}
sprite.events.onInputDown.add(callback, this)
```

I think this is weird, and to be honest cascading objects like this doesn't feel right to me. So I came up with:

```ruby
sprite.events.on(:down) do 
  puts "event down"
end
```

Or on a more complex case:

```ruby
class Player
  def create
     @sprite = game.add.sprite(x, y, sprite_key)
     @sprite.events.on(:down, self, &method(:down))
  end

  private
  def down
    puts "event down"
  end
end
```

To me this seems a better API, want some inputs on it. @ylluminarious 