### PR TITLE
State refactor

### DIFF
--- a/demo/app/main.rb
+++ b/demo/app/main.rb
@@ -159,9 +159,9 @@ class Game
   end
 
   def run
-    state = MainLevel.new
-    Phaser::Game.new(width: 800, height: 600, renderer: Phaser::AUTO, parent: '',
-                     state: state, transparent: false, antialias: true, physics: nil)
+    game = Phaser::Game.new
+    state = MainLevel.new(game)
+    game.state.add(:main, state, true)
   end
 end
 

--- a/demo/app/main.rb
+++ b/demo/app/main.rb
@@ -159,29 +159,26 @@ class Game
   end
 
   def run
-    preload
-    create_game
-    update_game
-
-    Phaser::Game.new(width: 800, height: 600, renderer: Phaser::AUTO, parent: '', state: state, transparent: false, antialias: true, physics: nil)
+    state = MainLevel.new
+    Phaser::Game.new(width: 800, height: 600, renderer: Phaser::AUTO, parent: '',
+                     state: state, transparent: false, antialias: true, physics: nil)
   end
+end
 
-  private
-
+class MainLevel < Phaser::State
   def preload
-    state.preload do |game|
-      initialize_entities(game)
-      entities_call :preload
-    end
+    pp game
+    puts "preload"
+    initialize_entities
+    entities_call :preload
   end
 
-  def create_game
-    state.create do
-      entities_call :create
-    end
+  def create
+    puts "create"
+    entities_call :create
   end
 
-  def update_game
+  def update
     collect_star = proc do |player, star, score|
       star = Phaser::Sprite.new(star)
       star.kill
@@ -190,20 +187,24 @@ class Game
       @score.scoreText.text = "score: #{@score.score}"
     end
 
-    state.update do |game|
-      game.physics.arcade.collide(@player.player, @platforms.platforms)
-      game.physics.arcade.collide(@star.stars, @platforms.platforms)
-      game.physics.arcade.overlap(@player.player, @star.stars, collect_star)
+    game.physics.arcade.collide(@player.player, @platforms.platforms)
+    game.physics.arcade.collide(@star.stars, @platforms.platforms)
+    game.physics.arcade.overlap(@player.player, @star.stars, collect_star)
 
-      @player.update
-    end
+    @player.update
   end
 
-  def state
-    @state ||= Phaser::State.new
+  private
+
+  def collect_star(player, star, score)
+    star = Phaser::Sprite.new(star)
+    star.kill
+
+    @score.score += 10
+    @score.scoreText.text = "score: #{@score.score}"
   end
 
-  def initialize_entities(game)
+  def initialize_entities
     @sky       = Sky.new(game)
     @platforms = Platforms.new(game)
     @player    = Player.new(game)

--- a/lib/opal/phaser/core/game.rb
+++ b/lib/opal/phaser/core/game.rb
@@ -28,11 +28,10 @@ module Phaser
 
       if state
         state.game = self
-      else
-        state = State.new(self)
       end
 
       if block_given?
+        state = State.new(self) if state.nil?
         state.instance_eval(&block)
       end
 
@@ -42,15 +41,16 @@ module Phaser
       }
     end
 
-    alias_native :cache,   :cache,   as: Cache
-    alias_native :add,     :add,     as: GameObjectFactory
-    alias_native :world,   :world,   as: World
-    alias_native :stage,   :stage,   as: Stage
-    alias_native :physics, :physics, as: Physics
-    alias_native :input,   :input,   as: Input
-    alias_native :time,    :time,    as: Time
-    alias_native :rnd,     :rnd,     as: RandomDataGenerator
-    alias_native :camera,  :camera,  as: Camera
+    alias_native :cache,    :cache,    as: Cache
+    alias_native :add,      :add,      as: GameObjectFactory
+    alias_native :world,    :world,    as: World
+    alias_native :stage,    :stage,    as: Stage
+    alias_native :state,    :state,    as: StateManager
+    alias_native :physics,  :physics,  as: Physics
+    alias_native :input,    :input,    as: Input
+    alias_native :time,     :time,     as: Time
+    alias_native :rnd,      :rnd,      as: RandomDataGenerator
+    alias_native :camera,   :camera,   as: Camera
 
     alias_native :make
     alias_native :load

--- a/lib/opal/phaser/core/game.rb
+++ b/lib/opal/phaser/core/game.rb
@@ -21,7 +21,7 @@ module Phaser
       height      = arg_hash.fetch(:height) { 600 }
       renderer    = arg_hash.fetch(:renderer) { Phaser::AUTO }
       parent      = arg_hash.fetch(:parent) { "" }
-      state       = arg_hash.fetch(:state) { Phaser::NilState }
+      state       = arg_hash.fetch(:state) { nil }
       transparent = arg_hash.fetch(:transparent) { false }
       antialias   = arg_hash.fetch(:antialias) { true }
       physics     = arg_hash.fetch(:physics) { nil }

--- a/lib/opal/phaser/core/game.rb
+++ b/lib/opal/phaser/core/game.rb
@@ -1,4 +1,12 @@
+require 'opal/phaser/loader/cache'
+require 'opal/phaser/game_objects/game_object_factory'
+require 'opal/phaser/core/world'
+require 'opal/phaser/core/stage'
+require 'opal/phaser/core/state_manager'
+require 'opal/phaser/input/input'
+require 'opal/phaser/math/random_data_generator'
 require 'opal/phaser/core/camera'
+
 module Phaser
   AUTO   = `Phaser.AUTO`
   WEBGL  = `Phaser.WEBGL`

--- a/lib/opal/phaser/core/state.rb
+++ b/lib/opal/phaser/core/state.rb
@@ -1,41 +1,47 @@
+require 'pp'
+require 'opal/phaser/core/game'
 module Phaser
   class State
-    attr_writer :game
+    include Native
     def initialize(game = nil, &block)
       @game    = game
       @native  = `new Phaser.State`
 
-      @preload = proc {}
-      @create  = proc {}
-      @update  = proc {}
-      @render  = proc {}
-
       if block_given?
         block.call(@game)
       end
+      super(@native)
     end
 
-
-    def preload(&block)
-      @preload = proc { block.call(@game) }
+    def game=(g_)
+      @game = g_
+      `#@native.game = #@game`
     end
 
-    def create(&block)
-      @create = proc { block.call(@game) }
+    def game
+      @game
     end
 
-    def update(&block)
-      @update = proc { block.call(@game) }
+    def preload
     end
 
-    def render(&block)
-      @render = proc { block.call(@game) }
+    def create
+    end
+
+    def update
+    end
+
+    def render
     end
 
     def to_n
+      _preload = proc { preload }
+      _create = proc { create }
+      _update = proc { update }
+      _render = proc { render }
       %x{
-        var obj = { preload: #@preload, create: #@create, update: #@update,
-                    render: #@render }
+        var obj = { preload: #{_preload}, create: #{_create}, update: #{_update},
+                    render: #{_render} }
       }
 
       return %x{ obj }

--- a/lib/opal/phaser/core/state.rb
+++ b/lib/opal/phaser/core/state.rb
@@ -4,8 +4,8 @@ module Phaser
   class State
     include Native
     def initialize(game = nil, &block)
-      @game    = game
       @native  = `new Phaser.State`
+      self.game    = game
 
       if block_given?
         block.call(@game)

--- a/lib/opal/phaser/core/state_manager.rb
+++ b/lib/opal/phaser/core/state_manager.rb
@@ -1,0 +1,7 @@
+module Phaser
+  class StateManager
+    include Native
+
+    alias_native :add
+  end
+end

--- a/lib/opal/phaser/game_objects/events.rb
+++ b/lib/opal/phaser/game_objects/events.rb
@@ -5,5 +5,18 @@ module Phaser
     include Native
 
     alias_native :on_input_down, :onInputDown, as: Signal
+
+    def on(type, context, &block)
+      case type.to_sym
+      when :up
+        `#@native.onInputUp.add(#{block.to_n}, #{context})`
+      when :down
+        `#@native.onInputDown.add(#{block.to_n}, #{context})`
+      when :out
+        `#@native.onInputOut.add(#{block.to_n}, #{context})`
+      when :over
+        `#@native.onInputOver.add(#{block.to_n}, #{context})`
+      end
+    end
   end
 end

--- a/lib/opal/phaser/game_objects/game_object_factory.rb
+++ b/lib/opal/phaser/game_objects/game_object_factory.rb
@@ -1,3 +1,11 @@
+require 'opal/phaser/game_objects/sprite'
+require 'opal/phaser/core/group'
+require 'opal/phaser/game_objects/text'
+require 'opal/phaser/game_objects/image'
+require 'opal/phaser/game_objects/bitmap_data'
+require 'opal/phaser/tween/tween'
+require 'opal/phaser/game_objects/tile_sprite'
+
 module Phaser
   class GameObjectFactory
     include Native

--- a/lib/opal/phaser/input/input.rb
+++ b/lib/opal/phaser/input/input.rb
@@ -1,3 +1,4 @@
+require 'opal/phaser/input/keyboard'
 require 'opal/phaser/input/pointer'
 module Phaser
   class Input

--- a/lib/opal/phaser/input/keyboard.rb
+++ b/lib/opal/phaser/input/keyboard.rb
@@ -1,17 +1,18 @@
+require 'opal/phaser/input/key'
 module Phaser
   class Keyboard
     include Native
-    
+
     SPACEBAR = `Phaser.Keyboard.SPACEBAR`
     LEFT     = `Phaser.Keyboard.LEFT`
     RIGHT    = `Phaser.Keyboard.RIGHT`
     A        = `Phaser.Keyboard.A`
     D        = `Phaser.Keyboard.D`
     ESC      = `Phaser.Keyboard.ESC`
-    
+
     alias_native :create_cursor_keys, :createCursorKeys
     alias_native :remove_key, :removeKey
-    
+
     alias_native :add_key, :addKey, as: Key
   end
 end

--- a/lib/opal/phaser/loader/cache.rb
+++ b/lib/opal/phaser/loader/cache.rb
@@ -1,3 +1,4 @@
+require 'opal/phaser/game_objects/image'
 module Phaser
   class Cache
     include Native


### PR DESCRIPTION
Again trying to make the Api more familiar to ruby programers.

Defining a state on Phaser.js is just a matter of providing a object with the correct properties:

```javascript
  var state = {
     preload: function() {},
     create: function() {},
     update: function() {}
  }
  var game = new Phaser::Game
  game.state.add('main', state, true)
```

This is pretty good for JS, but not so good  for Ruby. What I think when I created the current state API was to have a fast and similar way to define a game quickly, it was passing a block too the game

```ruby
  Phaser::Game.new do |state|
    preload {}
    create {}
    update {}
  end
```

I still think that this is a good Idea for rapid prototyping but felt weird when defining the state beforehand:

```ruby
   state = Phaser::State.new
   state.preload {}
   state.create {}
   state.update {}
   Phaser::Game.new state: state
```

So What i'm proposing here is having it more OO, so instead of instantiate a new state every time what we do is Inherit from Phaser::State, and override the necessary methods, this is for me as quick to prototype as the previous but more robust for more complex examples.

```ruby
   class BaseLevel < Phaser::State
      def update
      end
   end

   game = Phaser::Game.new state: BaseLevel.new
```

What you guys think? I haven't kept the old block syntax but could look into making the two compatible

